### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,5 +6,5 @@ Hasło do zipów można znależć na discordzie.
 [Strona Matematyczno Internetowego Koła Olimpijskiego](https://mikomath.org/)
 
 ### skrypty
-- `unpack.bat` - skrypt do rozpakowywania plików na linux'a
+- `unpack.sh` - skrypt do rozpakowywania plików na linux'a
 - `unpack.bat` - skrypt do rozpakowywania plików na windows'a (nie testowany)


### PR DESCRIPTION
The script for Linux should end with `.sh`.